### PR TITLE
feat: add basic ollama endpoint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Written in golang, it is very easy to install (single binary with no dependencie
   - `v1/rerank`, `v1/reranking`, `rerank`
   - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
   - `v1/audio/transcriptions` ([docs](https://github.com/mostlygeek/llama-swap/issues/41#issuecomment-2722637867))
+- ✅ Ollama API supported endpoints:
+  - `api/generate`
+  - `api/chat`
+  - `api/tags`
 - ✅ llama-swap custom API endpoints
   - `/ui` - web UI
   - `/log` - remote log monitoring


### PR DESCRIPTION
## Summary
- support `/api/generate`, `/api/chat`, and `/api/tags` endpoints for Ollama API compatibility
- translate Ollama requests to OpenAI-style calls and reshape responses
- document new Ollama endpoints in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895ff717ee08323900c23d447a9f1f5