### PR TITLE
feat: add missing Ollama API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ Written in golang, it is very easy to install (single binary with no dependencie
   - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
   - `v1/audio/transcriptions` ([docs](https://github.com/mostlygeek/llama-swap/issues/41#issuecomment-2722637867))
 - ✅ Ollama API supported endpoints:
+  - `HEAD /` - health check
+  - `api/tags` - list models
+  - `api/show` - model details
+  - `api/ps` - show running models
   - `api/generate`
   - `api/chat`
-  - `api/tags`
+  - `api/embed`
+  - `api/embeddings`
 - ✅ llama-swap custom API endpoints
   - `/ui` - web UI
   - `/log` - remote log monitoring


### PR DESCRIPTION
## Summary
- support Ollama embed, embeddings, show, ps, and head endpoints
- translate embedding requests and list running models for Ollama clients

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68960acd0b2883238a01e6f11c3e115d